### PR TITLE
use x86_64 instead of i686 which is no longer available

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const core = require('@actions/core');
 const tc = require('@actions/tool-cache');
 
 function getDownloadURL(version) {
-  url = `https://github.com/cargo-lambda/cargo-lambda/releases/download/${version}/cargo-lambda-${version}.i686-unknown-linux-musl.tar.gz`;
+  url = `https://github.com/cargo-lambda/cargo-lambda/releases/download/${version}/cargo-lambda-${version}.x86_64-unknown-linux-musl.tar.gz`;
   return url
 }
 


### PR DESCRIPTION
Starting from cargo-lambda v1.6.0, they don't have `i686` variant in their release assets. This PR changes the file name to be downloaded.